### PR TITLE
feat: implement docsify documentation for backend documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Rayuela Backend Documentation
+
+Welcome to the official documentation for the **Rayuela Backend**. 
+
+This repository contains the NestJS-based REST API and management backend for the Rayuela platform.
+
+## Quick Links
+- [Deployment](deployment)
+- [GitHub Repository](https://github.com/lucas-matw-unq/rayuela-NodeBackend)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,2 @@
+- [Home](README.md)
+- [Deployment](deployment.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,61 @@
+# Deployment: Stage Environment
+
+This page describes the architecture and deployment process for the Rayuela stage environment.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TB
+    Browser["🌐 Browser"]
+
+    subgraph Vercel["☁️ Vercel (Frontend)"]
+        VFE["rayuela-frontend\nStatic Site (SPA)"]
+    end
+
+    subgraph Atlas["🍃 MongoDB Atlas (Free Tier)"]
+        DB[("free-mongo-cluster\n.5pdg0du.mongodb.net/rayuela")]
+    end
+
+    subgraph Northflank["🚀 Northflank — Proyecto: rayuela (us-central)"]
+        subgraph ns["Namespace: ns-9v9rbv2pxhtx"]
+            BE["rayuela-NodeBackend\nNode.js :3000\np01--rayuela-nodebackend--9v9rbv2pxhtx.code.run\n[PUBLIC]"]
+            GR["garage\ndxflrs/garage:v2.2.0 :3900\np01--garage--9v9rbv2pxhtx.code.run\n[INTERNAL]"]
+        end
+    end
+
+    subgraph GitHub["🐙 GitHub (lucas-matw-unq)"]
+        REPO_BE["rayuela-NodeBackend\nbranch: feat/northflank-deployment"]
+        REPO_FE["rayuela-frontend"]
+    end
+
+    Browser -->|"HTTPS"| VFE
+    VFE -->|"VITE_ROOT_API\nhttps://.../v1"| BE
+    BE -->|"mongodb+srv://"| DB
+    BE -->|"http://garage:3900\nS3 API"| GR
+
+    REPO_BE -->|"CI build → deploy"| BE
+    REPO_FE -->|"CI deploy"| VFE
+```
+
+## Overview
+Rayuela uses a distributed cloud architecture:
+- **Frontend**: Hosted on Vercel as a Vue.js SPA.
+- **Backend**: NestJS application running on Northflank.
+- **Database**: Managed MongoDB Atlas cluster.
+- **Storage**: Garage (S3-compatible) running alongside the backend in Northflank.
+
+## Environment Variables
+The backend service (`rayuela-NodeBackend`) requires the following configuration:
+
+| Variable | Description | Value (Stage) |
+|----------|-------------|---------------|
+| `DB_CONNECTION` | MongoDB connection string | `mongodb+srv://...` |
+| `JWT_SECRET` | Secret key for JWT signing | `fda6c62...` |
+| `S3_ENDPOINT` | Garage S3 API endpoint | `http://garage:3900` |
+| `S3_ACCESS_KEY` | Garage Access Key | `GKeb4b3...` |
+| `S3_SECRET_KEY` | Garage Secret Key | `65cbf33...` |
+| `S3_BUCKET` | S3 bucket for check-ins | `rayuela-checkins` |
+| `S3_REGION` | S3 region identifier | `garage` |
+| `NOREPLY_EMAIL` | Email for notifications | `unqarq2@gmail.com` |
+| `FRONTEND_URL` | Production Frontend URL | `https://rayuela-frontend-nine.vercel.app` |
+| `NODE_ENV` | Environment mode | `production` |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Rayuela Backend Docs</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Documentation for Rayuela Backend.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'Rayuela Backend Docs',
+      repo: 'lucas-matw-unq/rayuela-NodeBackend',
+      loadSidebar: true,
+      subMaxLevel: 2,
+    }
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+  <!-- Mermaid Plugin -->
+  <script src="//cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script>
+    mermaid.initialize({ startOnLoad: false });
+
+    window.$docsify.markdown = {
+      renderer: {
+        code: function(code, lang) {
+          if (lang === "mermaid") {
+            return (
+              '<div class="mermaid">' + code + "</div>"
+            );
+          }
+          return this.origin.code.apply(this, arguments);
+        }
+      }
+    };
+
+    window.$docsify.plugins = [
+      function(hook, vm) {
+        hook.doneEach(function() {
+          mermaid.init(undefined, '.mermaid');
+        });
+      }
+    ];
+  </script>
+  <!-- PlantUML Plugin -->
+  <script src="//unpkg.com/docsify-plantuml/dist/docsify-plantuml.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces a new documentation system using Docsify.

### Changes:
- Initialized Docsify in the \`/docs\` folder.
- Configured a multi-page structure with sidebar navigation.
- Integrated Mermaid and PlantUML plugins.
- Added a detailed \`deployment.md\` page with the stage environment architecture diagram (rendered via Mermaid) and runtime environment variables.
- Added \`.nojekyll\` to ensure compatibility with GitHub Pages.

### Verification:
- Documentation was tested locally using a static server.
- Mermaid diagrams render correctly in the browser.

Please review the documentation structure and content. Once merged, GitHub Pages can be enabled pointing to the \`/docs\` folder.