### PR TITLE
docs: add offline sync link to sidebar

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
 
 - **Mobile Application**
   - [Architecture Overview](mobile/README.md)
+  - [Offline Sync Architecture](mobile/offline-sync.md)
   - [Project & Feature Structure](mobile/architecture.md)
   - [Technical Details](mobile/technical-details.md)
   - [Core Workflows](mobile/workflows.md)


### PR DESCRIPTION
The previous merge (#47) missed the sidebar link because it was pushed after the merge happened. This PR restores the link to the 'Offline Sync Architecture' page.