### PR TITLE
feat: add query filters and badge filter for community stats

### DIFF
--- a/src/module/analytics/analytics.controller.ts
+++ b/src/module/analytics/analytics.controller.ts
@@ -14,6 +14,8 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/role.decorator';
 import { UserRole } from '../auth/users/user.schema';
 
+import { AdminCheckinQueryDto } from '../checkin/dto/admin-checkin-query.dto';
+
 @Controller('analytics')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(UserRole.Admin)
@@ -95,8 +97,9 @@ export class AnalyticsController {
   @Get('project/:projectId/community-stats')
   getCommunityStats(
     @Param('projectId') projectId: string,
+    @Query() query: AdminCheckinQueryDto,
   ): Promise<any> {
-    return this.analyticsService.getCommunityStats(projectId);
+    return this.analyticsService.getCommunityStats(projectId, query);
   }
 
   @Get('summary')

--- a/src/module/analytics/analytics.controller.ts
+++ b/src/module/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
 import {
   ActiveUsersSeries,
@@ -90,6 +90,13 @@ export class AnalyticsController {
       startDate,
       endDate,
     );
+  }
+
+  @Get('project/:projectId/community-stats')
+  getCommunityStats(
+    @Param('projectId') projectId: string,
+  ): Promise<any> {
+    return this.analyticsService.getCommunityStats(projectId);
   }
 
   @Get('summary')

--- a/src/module/analytics/analytics.dao.ts
+++ b/src/module/analytics/analytics.dao.ts
@@ -1,6 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Document, PipelineStage } from 'mongoose';
+import { GeoUtils } from '../task/utils/geoUtils';
+import { TimeInterval } from '../task/entities/time-restriction.entity';
 import {
   CheckInDocument,
   CheckInTemplate,
@@ -356,5 +358,84 @@ export class AnalyticsDao {
       totalBadgesEarned: badgesResult[0]?.total ?? 0,
       totalPointsAwarded: pointsResult[0]?.total ?? 0,
     };
+  }
+
+  async communityStats(projectId: string): Promise<any> {
+    const project = await this.projectModel.findById(projectId).exec();
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    const checkins = await this.checkinModel.find({ projectId }).exec();
+    const checkinIds = checkins.map((c) => c._id.toString());
+    const moves = await this.moveModel.find({ checkinId: { $in: checkinIds } }).exec();
+    const moveByCheckinId = new Map<string, any>(
+      moves.map((m) => [m.checkinId, m]),
+    );
+
+    const areas = project.areas?.features || [];
+    const intervals = (project.timeIntervals || []).map(
+      (ti) => new TimeInterval(ti.name, ti.days, ti.time, new Date(ti.startDate), new Date(ti.endDate)),
+    );
+
+    const areaStatsMap = new Map<string, { areaName: string; checkinsCount: number; totalPoints: number; totalBadges: number }>();
+    for (const area of areas) {
+      const areaId = area.properties.id || area.properties.name || 'Unknown';
+      const areaName = area.properties.name || areaId;
+      areaStatsMap.set(areaId.toString(), { areaName, checkinsCount: 0, totalPoints: 0, totalBadges: 0 });
+    }
+    areaStatsMap.set('Outside Area', { areaName: 'Fuera de Área', checkinsCount: 0, totalPoints: 0, totalBadges: 0 });
+
+    const taskTypeStatsMap = new Map<string, number>();
+    const intervalStatsMap = new Map<string, number>();
+
+    for (const ch of checkins) {
+      const move = moveByCheckinId.get(ch._id.toString());
+      const points = move?.newPoints || 0;
+      const badgesCount = move?.newBadges?.length || 0;
+
+      let matchedAreaId = 'Outside Area';
+      for (const area of areas) {
+        const areaId = area.properties.id || area.properties.name || 'Unknown';
+        if (GeoUtils.isPointInPolygon(parseFloat(ch.longitude), parseFloat(ch.latitude), area.geometry)) {
+          matchedAreaId = areaId.toString();
+          break;
+        }
+      }
+
+      const areaStat = areaStatsMap.get(matchedAreaId);
+      if (areaStat) {
+        areaStat.checkinsCount++;
+        areaStat.totalPoints += points;
+        areaStat.totalBadges += badgesCount;
+      }
+
+      const tType = ch.taskType || 'Unknown';
+      taskTypeStatsMap.set(tType, (taskTypeStatsMap.get(tType) || 0) + 1);
+
+      let matchedInterval = 'Cualquiera';
+      for (const ti of intervals) {
+        if (ti.satisfy(ch.datetime)) {
+          matchedInterval = ti.name;
+          break;
+        }
+      }
+      intervalStatsMap.set(matchedInterval, (intervalStatsMap.get(matchedInterval) || 0) + 1);
+    }
+
+    const byArea = Array.from(areaStatsMap.entries()).map(([areaId, val]) => ({
+      areaId,
+      ...val,
+    }));
+    const byTaskType = Array.from(taskTypeStatsMap.entries()).map(([taskType, checkinsCount]) => ({
+      taskType,
+      checkinsCount,
+    }));
+    const byInterval = Array.from(intervalStatsMap.entries()).map(([timeIntervalId, checkinsCount]) => ({
+      timeIntervalId,
+      checkinsCount,
+    }));
+
+    return { byArea, byTaskType, byInterval };
   }
 }

--- a/src/module/analytics/analytics.dao.ts
+++ b/src/module/analytics/analytics.dao.ts
@@ -1,6 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, PipelineStage, Types } from 'mongoose';
+import {
+  FilterQuery,
+  HydratedDocument,
+  Model,
+  PipelineStage,
+  Types,
+} from 'mongoose';
 import { GeoUtils } from '../task/utils/geoUtils';
 import { TimeInterval } from '../task/entities/time-restriction.entity';
 import {
@@ -20,11 +26,15 @@ import {
 import { UserDocument, UserTemplate } from '../auth/users/user.schema';
 import {
   ActiveUsersSeries,
+  AreaStat,
+  CommunityStats,
   ContributionRate,
   Granularity,
+  IntervalStat,
   PointsSeries,
   StrategyBreakdown,
   SummaryStats,
+  TaskTypeStat,
   TimeSeries,
 } from './analytics.types';
 
@@ -368,128 +378,201 @@ export class AnalyticsDao {
     };
   }
 
+  /**
+   * Builds community-level statistics for a project's check-ins, grouped by
+   * area, task type and time interval. Each group reports the check-in count,
+   * and areas also accumulate the points and badges awarded by the related
+   * `Move`.
+   *
+   * `query` carries the optional admin filters (badge, task name/type, user,
+   * photos, contribution, date range and geo radius). It is bound by NestJS
+   * from the query string of `GET /analytics/project/:projectId/community-stats`
+   * (`@Query() query: AdminCheckinQueryDto` in `AnalyticsController`); the DTO is
+   * the same one used by the admin check-in listing endpoint.
+   *
+   * The work is split into helpers: `buildCommunityStatsFilter` turns the query
+   * into a Mongo filter, `applyGeoRadiusFilter` narrows results to a geographic
+   * radius in memory, and `buildCommunityStatsResult` performs the aggregation.
+   */
   async communityStats(
     projectId: string,
     query?: AdminCheckinQueryDto,
-  ): Promise<any> {
+  ): Promise<CommunityStats> {
     const project = await this.projectModel.findById(projectId).exec();
     if (!project) {
       throw new NotFoundException('Project not found');
     }
 
-    const mongoFilter: any = { projectId };
-
-    if (query) {
-      if (query.taskType && query.taskType.trim().length > 0) {
-        mongoFilter.taskType = query.taskType.trim();
-      }
-
-      if (query.userId && query.userId.trim().length > 0) {
-        mongoFilter.userId = query.userId.trim();
-      }
-
-      if (query.badgeName && query.badgeName.trim().length > 0) {
-        const moves = await this.moveModel
-          .find({ newBadges: query.badgeName.trim() })
-          .exec();
-        const checkinIdIn = moves.map((m) => m.checkinId);
-        if (checkinIdIn.length === 0) {
-          return { byArea: [], byTaskType: [], byInterval: [] };
-        }
-        mongoFilter._id = { $in: checkinIdIn };
-      }
-
-      if (query.taskName && query.taskName.trim().length > 0) {
-        const needle = query.taskName.trim().toLowerCase();
-        let projIdObj: any;
-        try {
-          projIdObj = new Types.ObjectId(projectId);
-        } catch {
-          projIdObj = projectId;
-        }
-        const tasks = await this.taskModel
-          .find({ projectId: projIdObj })
-          .exec();
-        const taskIdIn = tasks
-          .filter(
-            (t) =>
-              (t.name && t.name.toLowerCase().includes(needle)) ||
-              (t.description && t.description.toLowerCase().includes(needle)),
-          )
-          .map((t) => t._id.toString());
-        if (taskIdIn.length === 0) {
-          return { byArea: [], byTaskType: [], byInterval: [] };
-        }
-        mongoFilter.contributesTo = { $in: taskIdIn };
-      } else if (query.contributed === 'true') {
-        mongoFilter.contributesTo = { $nin: [null, ''] };
-      } else if (query.contributed === 'false') {
-        mongoFilter.$or = [
-          { contributesTo: { $exists: false } },
-          { contributesTo: null },
-          { contributesTo: '' },
-        ];
-      }
-
-      if (query.hasPhotos === 'true') {
-        mongoFilter['imageRefs.0'] = { $exists: true };
-      } else if (query.hasPhotos === 'false') {
-        mongoFilter.$and = [
-          ...((mongoFilter.$and as object[]) || []),
-          {
-            $or: [
-              { imageRefs: { $exists: false } },
-              { imageRefs: { $size: 0 } },
-            ],
-          },
-        ];
-      }
-
-      if (query.dateFrom || query.dateTo) {
-        mongoFilter.datetime = {};
-        if (query.dateFrom) {
-          mongoFilter.datetime.$gte = new Date(query.dateFrom);
-        }
-        if (query.dateTo) {
-          const end = new Date(query.dateTo);
-          end.setUTCHours(23, 59, 59, 999);
-          mongoFilter.datetime.$lte = end;
-        }
-      }
+    const { filter, hasNoResults } = await this.buildCommunityStatsFilter(
+      projectId,
+      query,
+    );
+    if (hasNoResults) {
+      return { byArea: [], byTaskType: [], byInterval: [] };
     }
 
-    let checkins = await this.checkinModel.find(mongoFilter).exec();
-
-    if (query && query.latitude && query.longitude && query.radiusKm) {
-      const centerLat = parseFloat(query.latitude);
-      const centerLng = parseFloat(query.longitude);
-      const radiusKm = parseFloat(query.radiusKm);
-      if (
-        !Number.isNaN(centerLat) &&
-        !Number.isNaN(centerLng) &&
-        !Number.isNaN(radiusKm) &&
-        radiusKm > 0
-      ) {
-        checkins = checkins.filter((c) =>
-          AnalyticsDao.withinRadius(
-            Number(c.latitude),
-            Number(c.longitude),
-            centerLat,
-            centerLng,
-            radiusKm,
-          ),
-        );
-      }
-    }
+    let checkins = await this.checkinModel.find(filter).exec();
+    checkins = AnalyticsDao.applyGeoRadiusFilter(checkins, query);
 
     const checkinIds = checkins.map((c) => c._id.toString());
     const moves = await this.moveModel
       .find({ checkinId: { $in: checkinIds } })
       .exec();
-    const moveByCheckinId = new Map<string, any>(
+    const moveByCheckinId = new Map<string, MoveDocument>(
       moves.map((m) => [m.checkinId, m]),
     );
 
+    return this.buildCommunityStatsResult(project, checkins, moveByCheckinId);
+  }
+
+  /**
+   * Translates the admin query filters into a Mongo filter for check-ins.
+   *
+   * Returns `hasNoResults: true` when a filter (badge or task name) matches
+   * nothing, so the caller can short-circuit with an empty response instead of
+   * running a query that can never match.
+   */
+  private async buildCommunityStatsFilter(
+    projectId: string,
+    query?: AdminCheckinQueryDto,
+  ): Promise<{ filter: FilterQuery<CheckInDocument>; hasNoResults: boolean }> {
+    const filter: FilterQuery<CheckInDocument> = { projectId };
+
+    if (!query) {
+      return { filter, hasNoResults: false };
+    }
+
+    if (query.taskType && query.taskType.trim().length > 0) {
+      filter.taskType = query.taskType.trim();
+    }
+
+    if (query.userId && query.userId.trim().length > 0) {
+      filter.userId = query.userId.trim();
+    }
+
+    if (query.badgeName && query.badgeName.trim().length > 0) {
+      const moves = await this.moveModel
+        .find({ newBadges: query.badgeName.trim() })
+        .exec();
+      const checkinIdIn = moves.map((m) => m.checkinId);
+      if (checkinIdIn.length === 0) {
+        return { filter, hasNoResults: true };
+      }
+      filter._id = { $in: checkinIdIn };
+    }
+
+    if (query.taskName && query.taskName.trim().length > 0) {
+      const taskIdIn = await this.findTaskIdsByName(projectId, query.taskName);
+      if (taskIdIn.length === 0) {
+        return { filter, hasNoResults: true };
+      }
+      filter.contributesTo = { $in: taskIdIn };
+    } else if (query.contributed === 'true') {
+      filter.contributesTo = { $nin: [null, ''] };
+    } else if (query.contributed === 'false') {
+      filter.$or = [
+        { contributesTo: { $exists: false } },
+        { contributesTo: null },
+        { contributesTo: '' },
+      ];
+    }
+
+    if (query.hasPhotos === 'true') {
+      filter['imageRefs.0'] = { $exists: true };
+    } else if (query.hasPhotos === 'false') {
+      filter.$and = [
+        ...((filter.$and as object[]) || []),
+        {
+          $or: [{ imageRefs: { $exists: false } }, { imageRefs: { $size: 0 } }],
+        },
+      ];
+    }
+
+    if (query.dateFrom || query.dateTo) {
+      const datetime: { $gte?: Date; $lte?: Date } = {};
+      if (query.dateFrom) {
+        datetime.$gte = new Date(query.dateFrom);
+      }
+      if (query.dateTo) {
+        const end = new Date(query.dateTo);
+        end.setUTCHours(23, 59, 59, 999);
+        datetime.$lte = end;
+      }
+      filter.datetime = datetime;
+    }
+
+    return { filter, hasNoResults: false };
+  }
+
+  /**
+   * Resolves the ids of a project's tasks whose name or description contains
+   * `taskName` (case-insensitive, partial match). The match is pushed down to
+   * Mongo so we don't load every project task into memory.
+   */
+  private async findTaskIdsByName(
+    projectId: string,
+    taskName: string,
+  ): Promise<string[]> {
+    let projIdObj: Types.ObjectId | string;
+    try {
+      projIdObj = new Types.ObjectId(projectId);
+    } catch {
+      projIdObj = projectId;
+    }
+    const rx = new RegExp(AnalyticsDao.escapeRegExp(taskName.trim()), 'i');
+    const tasks = await this.taskModel
+      .find({ projectId: projIdObj, $or: [{ name: rx }, { description: rx }] })
+      .exec();
+    return tasks.map((t) => t._id.toString());
+  }
+
+  /** Escapes regex metacharacters so user input is matched literally. */
+  private static escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * Narrows check-ins to those within `radiusKm` of the query's lat/lng centre.
+   * Returns the input unchanged when the radius filter is absent or invalid.
+   */
+  private static applyGeoRadiusFilter<
+    T extends { latitude: string; longitude: string },
+  >(checkins: T[], query?: AdminCheckinQueryDto): T[] {
+    if (!query || !query.latitude || !query.longitude || !query.radiusKm) {
+      return checkins;
+    }
+    const centerLat = parseFloat(query.latitude);
+    const centerLng = parseFloat(query.longitude);
+    const radiusKm = parseFloat(query.radiusKm);
+    if (
+      Number.isNaN(centerLat) ||
+      Number.isNaN(centerLng) ||
+      Number.isNaN(radiusKm) ||
+      radiusKm <= 0
+    ) {
+      return checkins;
+    }
+    return checkins.filter((c) =>
+      AnalyticsDao.withinRadius(
+        Number(c.latitude),
+        Number(c.longitude),
+        centerLat,
+        centerLng,
+        radiusKm,
+      ),
+    );
+  }
+
+  /**
+   * Aggregates check-ins into per-area, per-task-type and per-interval counts,
+   * attributing each check-in's points and badges (from its `Move`) to the area
+   * whose polygon contains it (or "Outside Area" when none match).
+   */
+  private buildCommunityStatsResult(
+    project: ProjectDocument,
+    checkins: HydratedDocument<CheckInDocument>[],
+    moveByCheckinId: Map<string, MoveDocument>,
+  ): CommunityStats {
     const areas = project.areas?.features || [];
     const intervals = (project.timeIntervals || []).map(
       (ti) =>
@@ -502,15 +585,7 @@ export class AnalyticsDao {
         ),
     );
 
-    const areaStatsMap = new Map<
-      string,
-      {
-        areaName: string;
-        checkinsCount: number;
-        totalPoints: number;
-        totalBadges: number;
-      }
-    >();
+    const areaStatsMap = new Map<string, Omit<AreaStat, 'areaId'>>();
     for (const area of areas) {
       const areaId = area.properties.id || area.properties.name || 'Unknown';
       const areaName = area.properties.name || areaId;
@@ -574,22 +649,18 @@ export class AnalyticsDao {
       );
     }
 
-    const byArea = Array.from(areaStatsMap.entries()).map(([areaId, val]) => ({
-      areaId,
-      ...val,
+    const byArea: AreaStat[] = Array.from(areaStatsMap.entries()).map(
+      ([areaId, val]) => ({ areaId, ...val }),
+    );
+    const byTaskType: TaskTypeStat[] = Array.from(
+      taskTypeStatsMap.entries(),
+    ).map(([taskType, checkinsCount]) => ({ taskType, checkinsCount }));
+    const byInterval: IntervalStat[] = Array.from(
+      intervalStatsMap.entries(),
+    ).map(([timeIntervalId, checkinsCount]) => ({
+      timeIntervalId,
+      checkinsCount,
     }));
-    const byTaskType = Array.from(taskTypeStatsMap.entries()).map(
-      ([taskType, checkinsCount]) => ({
-        taskType,
-        checkinsCount,
-      }),
-    );
-    const byInterval = Array.from(intervalStatsMap.entries()).map(
-      ([timeIntervalId, checkinsCount]) => ({
-        timeIntervalId,
-        checkinsCount,
-      }),
-    );
 
     return { byArea, byTaskType, byInterval };
   }

--- a/src/module/analytics/analytics.dao.ts
+++ b/src/module/analytics/analytics.dao.ts
@@ -1,8 +1,13 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, Document, PipelineStage } from 'mongoose';
+import { Model, PipelineStage, Types } from 'mongoose';
 import { GeoUtils } from '../task/utils/geoUtils';
 import { TimeInterval } from '../task/entities/time-restriction.entity';
+import {
+  TaskSchemaTemplate,
+  TaskDocument,
+} from '../task/persistence/task.schema';
+import { AdminCheckinQueryDto } from '../checkin/dto/admin-checkin-query.dto';
 import {
   CheckInDocument,
   CheckInTemplate,
@@ -37,6 +42,9 @@ export class AnalyticsDao {
 
     @InjectModel(UserTemplate.collectionName())
     private readonly userModel: Model<UserDocument>,
+
+    @InjectModel(TaskSchemaTemplate.collectionName())
+    private readonly taskModel: Model<TaskDocument>,
   ) {}
 
   private buildDateBucket(granularity: Granularity, field: string) {
@@ -360,31 +368,165 @@ export class AnalyticsDao {
     };
   }
 
-  async communityStats(projectId: string): Promise<any> {
+  async communityStats(
+    projectId: string,
+    query?: AdminCheckinQueryDto,
+  ): Promise<any> {
     const project = await this.projectModel.findById(projectId).exec();
     if (!project) {
       throw new NotFoundException('Project not found');
     }
 
-    const checkins = await this.checkinModel.find({ projectId }).exec();
+    const mongoFilter: any = { projectId };
+
+    if (query) {
+      if (query.taskType && query.taskType.trim().length > 0) {
+        mongoFilter.taskType = query.taskType.trim();
+      }
+
+      if (query.userId && query.userId.trim().length > 0) {
+        mongoFilter.userId = query.userId.trim();
+      }
+
+      if (query.badgeName && query.badgeName.trim().length > 0) {
+        const moves = await this.moveModel
+          .find({ newBadges: query.badgeName.trim() })
+          .exec();
+        const checkinIdIn = moves.map((m) => m.checkinId);
+        if (checkinIdIn.length === 0) {
+          return { byArea: [], byTaskType: [], byInterval: [] };
+        }
+        mongoFilter._id = { $in: checkinIdIn };
+      }
+
+      if (query.taskName && query.taskName.trim().length > 0) {
+        const needle = query.taskName.trim().toLowerCase();
+        let projIdObj: any;
+        try {
+          projIdObj = new Types.ObjectId(projectId);
+        } catch {
+          projIdObj = projectId;
+        }
+        const tasks = await this.taskModel
+          .find({ projectId: projIdObj })
+          .exec();
+        const taskIdIn = tasks
+          .filter(
+            (t) =>
+              (t.name && t.name.toLowerCase().includes(needle)) ||
+              (t.description && t.description.toLowerCase().includes(needle)),
+          )
+          .map((t) => t._id.toString());
+        if (taskIdIn.length === 0) {
+          return { byArea: [], byTaskType: [], byInterval: [] };
+        }
+        mongoFilter.contributesTo = { $in: taskIdIn };
+      } else if (query.contributed === 'true') {
+        mongoFilter.contributesTo = { $nin: [null, ''] };
+      } else if (query.contributed === 'false') {
+        mongoFilter.$or = [
+          { contributesTo: { $exists: false } },
+          { contributesTo: null },
+          { contributesTo: '' },
+        ];
+      }
+
+      if (query.hasPhotos === 'true') {
+        mongoFilter['imageRefs.0'] = { $exists: true };
+      } else if (query.hasPhotos === 'false') {
+        mongoFilter.$and = [
+          ...((mongoFilter.$and as object[]) || []),
+          {
+            $or: [
+              { imageRefs: { $exists: false } },
+              { imageRefs: { $size: 0 } },
+            ],
+          },
+        ];
+      }
+
+      if (query.dateFrom || query.dateTo) {
+        mongoFilter.datetime = {};
+        if (query.dateFrom) {
+          mongoFilter.datetime.$gte = new Date(query.dateFrom);
+        }
+        if (query.dateTo) {
+          const end = new Date(query.dateTo);
+          end.setUTCHours(23, 59, 59, 999);
+          mongoFilter.datetime.$lte = end;
+        }
+      }
+    }
+
+    let checkins = await this.checkinModel.find(mongoFilter).exec();
+
+    if (query && query.latitude && query.longitude && query.radiusKm) {
+      const centerLat = parseFloat(query.latitude);
+      const centerLng = parseFloat(query.longitude);
+      const radiusKm = parseFloat(query.radiusKm);
+      if (
+        !Number.isNaN(centerLat) &&
+        !Number.isNaN(centerLng) &&
+        !Number.isNaN(radiusKm) &&
+        radiusKm > 0
+      ) {
+        checkins = checkins.filter((c) =>
+          AnalyticsDao.withinRadius(
+            Number(c.latitude),
+            Number(c.longitude),
+            centerLat,
+            centerLng,
+            radiusKm,
+          ),
+        );
+      }
+    }
+
     const checkinIds = checkins.map((c) => c._id.toString());
-    const moves = await this.moveModel.find({ checkinId: { $in: checkinIds } }).exec();
+    const moves = await this.moveModel
+      .find({ checkinId: { $in: checkinIds } })
+      .exec();
     const moveByCheckinId = new Map<string, any>(
       moves.map((m) => [m.checkinId, m]),
     );
 
     const areas = project.areas?.features || [];
     const intervals = (project.timeIntervals || []).map(
-      (ti) => new TimeInterval(ti.name, ti.days, ti.time, new Date(ti.startDate), new Date(ti.endDate)),
+      (ti) =>
+        new TimeInterval(
+          ti.name,
+          ti.days,
+          ti.time,
+          new Date(ti.startDate),
+          new Date(ti.endDate),
+        ),
     );
 
-    const areaStatsMap = new Map<string, { areaName: string; checkinsCount: number; totalPoints: number; totalBadges: number }>();
+    const areaStatsMap = new Map<
+      string,
+      {
+        areaName: string;
+        checkinsCount: number;
+        totalPoints: number;
+        totalBadges: number;
+      }
+    >();
     for (const area of areas) {
       const areaId = area.properties.id || area.properties.name || 'Unknown';
       const areaName = area.properties.name || areaId;
-      areaStatsMap.set(areaId.toString(), { areaName, checkinsCount: 0, totalPoints: 0, totalBadges: 0 });
+      areaStatsMap.set(areaId.toString(), {
+        areaName,
+        checkinsCount: 0,
+        totalPoints: 0,
+        totalBadges: 0,
+      });
     }
-    areaStatsMap.set('Outside Area', { areaName: 'Fuera de Área', checkinsCount: 0, totalPoints: 0, totalBadges: 0 });
+    areaStatsMap.set('Outside Area', {
+      areaName: 'Fuera de Área',
+      checkinsCount: 0,
+      totalPoints: 0,
+      totalBadges: 0,
+    });
 
     const taskTypeStatsMap = new Map<string, number>();
     const intervalStatsMap = new Map<string, number>();
@@ -397,7 +539,13 @@ export class AnalyticsDao {
       let matchedAreaId = 'Outside Area';
       for (const area of areas) {
         const areaId = area.properties.id || area.properties.name || 'Unknown';
-        if (GeoUtils.isPointInPolygon(parseFloat(ch.longitude), parseFloat(ch.latitude), area.geometry)) {
+        if (
+          GeoUtils.isPointInPolygon(
+            parseFloat(ch.longitude),
+            parseFloat(ch.latitude),
+            area.geometry,
+          )
+        ) {
           matchedAreaId = areaId.toString();
           break;
         }
@@ -420,22 +568,50 @@ export class AnalyticsDao {
           break;
         }
       }
-      intervalStatsMap.set(matchedInterval, (intervalStatsMap.get(matchedInterval) || 0) + 1);
+      intervalStatsMap.set(
+        matchedInterval,
+        (intervalStatsMap.get(matchedInterval) || 0) + 1,
+      );
     }
 
     const byArea = Array.from(areaStatsMap.entries()).map(([areaId, val]) => ({
       areaId,
       ...val,
     }));
-    const byTaskType = Array.from(taskTypeStatsMap.entries()).map(([taskType, checkinsCount]) => ({
-      taskType,
-      checkinsCount,
-    }));
-    const byInterval = Array.from(intervalStatsMap.entries()).map(([timeIntervalId, checkinsCount]) => ({
-      timeIntervalId,
-      checkinsCount,
-    }));
+    const byTaskType = Array.from(taskTypeStatsMap.entries()).map(
+      ([taskType, checkinsCount]) => ({
+        taskType,
+        checkinsCount,
+      }),
+    );
+    const byInterval = Array.from(intervalStatsMap.entries()).map(
+      ([timeIntervalId, checkinsCount]) => ({
+        timeIntervalId,
+        checkinsCount,
+      }),
+    );
 
     return { byArea, byTaskType, byInterval };
+  }
+
+  private static withinRadius(
+    lat: number,
+    lng: number,
+    centerLat: number,
+    centerLng: number,
+    radiusKm: number,
+  ): boolean {
+    if (Number.isNaN(lat) || Number.isNaN(lng)) return false;
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const dLat = toRad(lat - centerLat);
+    const dLng = toRad(lng - centerLng);
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(centerLat)) *
+        Math.cos(toRad(lat)) *
+        Math.sin(dLng / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    const EARTH_RADIUS_KM = 6371;
+    return EARTH_RADIUS_KM * c <= radiusKm;
   }
 }

--- a/src/module/analytics/analytics.module.ts
+++ b/src/module/analytics/analytics.module.ts
@@ -12,6 +12,10 @@ import {
   ProjectSchema,
   ProjectTemplate,
 } from '../project/persistence/project.schema';
+import {
+  TaskSchema,
+  TaskSchemaTemplate,
+} from '../task/persistence/task.schema';
 import { UserSchema, UserTemplate } from '../auth/users/user.schema';
 
 @Module({
@@ -21,6 +25,7 @@ import { UserSchema, UserTemplate } from '../auth/users/user.schema';
       { name: MoveTemplate.collectionName(), schema: MoveSchema },
       { name: ProjectTemplate.collectionName(), schema: ProjectSchema },
       { name: UserTemplate.collectionName(), schema: UserSchema },
+      { name: TaskSchemaTemplate.collectionName(), schema: TaskSchema },
     ]),
   ],
   controllers: [AnalyticsController],

--- a/src/module/analytics/analytics.service.ts
+++ b/src/module/analytics/analytics.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { AnalyticsDao } from './analytics.dao';
 import { Granularity } from './analytics.types';
+import { AdminCheckinQueryDto } from '../checkin/dto/admin-checkin-query.dto';
 
 @Injectable()
 export class AnalyticsService {
@@ -70,8 +71,8 @@ export class AnalyticsService {
     );
   }
 
-  getCommunityStats(projectId: string) {
-    return this.analyticsDao.communityStats(projectId);
+  getCommunityStats(projectId: string, query?: AdminCheckinQueryDto) {
+    return this.analyticsDao.communityStats(projectId, query);
   }
 
   getSummary(projectId?: string, startDate?: string, endDate?: string) {

--- a/src/module/analytics/analytics.service.ts
+++ b/src/module/analytics/analytics.service.ts
@@ -70,6 +70,10 @@ export class AnalyticsService {
     );
   }
 
+  getCommunityStats(projectId: string) {
+    return this.analyticsDao.communityStats(projectId);
+  }
+
   getSummary(projectId?: string, startDate?: string, endDate?: string) {
     return this.analyticsDao.summary(projectId, startDate, endDate);
   }

--- a/src/module/analytics/analytics.types.ts
+++ b/src/module/analytics/analytics.types.ts
@@ -42,3 +42,31 @@ export interface SummaryStats {
   totalBadgesEarned: number;
   totalPointsAwarded: number;
 }
+
+/** Per-area aggregation row returned by `communityStats`. */
+export interface AreaStat {
+  areaId: string;
+  areaName: string;
+  checkinsCount: number;
+  totalPoints: number;
+  totalBadges: number;
+}
+
+/** Per-task-type aggregation row returned by `communityStats`. */
+export interface TaskTypeStat {
+  taskType: string;
+  checkinsCount: number;
+}
+
+/** Per-time-interval aggregation row returned by `communityStats`. */
+export interface IntervalStat {
+  timeIntervalId: string;
+  checkinsCount: number;
+}
+
+/** Shape of the community-stats endpoint response. */
+export interface CommunityStats {
+  byArea: AreaStat[];
+  byTaskType: TaskTypeStat[];
+  byInterval: IntervalStat[];
+}

--- a/src/module/checkin/checkin.service.spec.ts
+++ b/src/module/checkin/checkin.service.spec.ts
@@ -38,6 +38,8 @@ const mockStorageService = {
 
 const mockMoveDao = {
   create: jest.fn(),
+  findMovesByCheckinIds: jest.fn().mockResolvedValue([]),
+  findMovesByBadge: jest.fn().mockResolvedValue([]),
 };
 
 const mockTaskService = {

--- a/src/module/checkin/checkin.service.ts
+++ b/src/module/checkin/checkin.service.ts
@@ -233,6 +233,15 @@ export class CheckinService {
     );
     const page = Math.max(1, parseIntSafe(query.page, 1));
 
+    let checkinIdIn: string[] | undefined;
+    if (query.badgeName && query.badgeName.trim().length > 0) {
+      const moves = await this.moveDao.findMovesByBadge(query.badgeName.trim());
+      checkinIdIn = moves.map((m) => m.checkinId);
+      if (checkinIdIn.length === 0) {
+        return { items: [], total: 0, page, limit };
+      }
+    }
+
     let taskIdIn: string[] | undefined;
     let projectTasks: Task[] | null = null;
     if (query.taskName && query.taskName.trim().length > 0) {
@@ -256,6 +265,7 @@ export class CheckinService {
       taskType: query.taskType?.trim() || undefined,
       userId: query.userId?.trim() || undefined,
       taskIdIn,
+      checkinIdIn,
       hasPhotos: parseBool(query.hasPhotos),
       contributed: parseBool(query.contributed),
       dateFrom: parseDate(query.dateFrom),
@@ -282,15 +292,25 @@ export class CheckinService {
     const taskById = new Map<string, Task>(
       projectTasks.map((t) => [t.getId().toString(), t]),
     );
+
+    const checkinIds = result.items.map((c: any) => c._id.toString());
+    const moves = await this.moveDao.findMovesByCheckinIds(checkinIds);
+    const moveByCheckinId = new Map<string, any>(
+      moves.map((m) => [m.checkinId, m]),
+    );
+
     const items = result.items.map((c: any) => {
       const plain = typeof c.toObject === 'function' ? c.toObject() : c;
       const task = plain.contributesTo
         ? taskById.get(plain.contributesTo.toString())
         : undefined;
+      const move = moveByCheckinId.get(plain._id.toString());
       return {
         ...plain,
         taskName: task?.name || null,
         taskDescription: task?.description || null,
+        newPoints: move?.newPoints || 0,
+        newBadges: move?.newBadges || [],
       };
     });
 

--- a/src/module/checkin/checkin.service.ts
+++ b/src/module/checkin/checkin.service.ts
@@ -282,7 +282,12 @@ export class CheckinService {
 
     // Skip the task-enrichment DB call when there is nothing to enrich.
     if (result.items.length === 0) {
-      return { items: [], total: result.total, page: result.page, limit: result.limit };
+      return {
+        items: [],
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+      };
     }
 
     // Build an id→task map once so the response can include task name + type.

--- a/src/module/checkin/checkin.service.ts
+++ b/src/module/checkin/checkin.service.ts
@@ -11,6 +11,7 @@ import { Move } from './entities/move.entity';
 import { GameBuilder } from './entities/game.entity';
 import { ProjectService, UserStatus } from '../project/project.service';
 import { MoveDao } from './persistence/move.dao';
+import { MoveDocument } from './persistence/move.schema';
 import { GamificationService } from '../gamification/gamification.service';
 import { Project } from '../project/entities/project';
 import { User } from '../auth/users/user.entity';
@@ -298,13 +299,13 @@ export class CheckinService {
       projectTasks.map((t) => [t.getId().toString(), t]),
     );
 
-    const checkinIds = result.items.map((c: any) => c._id.toString());
+    const checkinIds = result.items.map((c) => c._id.toString());
     const moves = await this.moveDao.findMovesByCheckinIds(checkinIds);
-    const moveByCheckinId = new Map<string, any>(
+    const moveByCheckinId = new Map<string, MoveDocument>(
       moves.map((m) => [m.checkinId, m]),
     );
 
-    const items = result.items.map((c: any) => {
+    const items = result.items.map((c) => {
       const plain = typeof c.toObject === 'function' ? c.toObject() : c;
       const task = plain.contributesTo
         ? taskById.get(plain.contributesTo.toString())

--- a/src/module/checkin/dto/admin-checkin-query.dto.ts
+++ b/src/module/checkin/dto/admin-checkin-query.dto.ts
@@ -12,6 +12,9 @@ export class AdminCheckinQueryDto {
   /** Filter by task type as stored on the checkin (exact match). */
   taskType?: string;
 
+  /** Filter by badge name unlocked during checkin (exact match). */
+  badgeName?: string;
+
   /** Restrict to checkins authored by a specific user. */
   userId?: string;
 

--- a/src/module/checkin/persistence/CheckinMapper.ts
+++ b/src/module/checkin/persistence/CheckinMapper.ts
@@ -1,6 +1,6 @@
 import { User } from '../../auth/users/user.entity';
 import { Checkin } from '../entities/checkin.entity';
-import { CheckInDocument, CheckInTemplate } from './checkin.schema';
+import { CheckInTemplate } from './checkin.schema';
 
 export class CheckinMapper {
   /**

--- a/src/module/checkin/persistence/checkin.dao.ts
+++ b/src/module/checkin/persistence/checkin.dao.ts
@@ -36,7 +36,7 @@ export interface AdminCheckinFilter {
 }
 
 export interface AdminCheckinPage {
-  items: CheckInTemplate[];
+  items: CheckInDocument[];
   total: number;
   page: number;
   limit: number;

--- a/src/module/checkin/persistence/checkin.dao.ts
+++ b/src/module/checkin/persistence/checkin.dao.ts
@@ -17,6 +17,8 @@ export interface AdminCheckinFilter {
   userId?: string;
   /** Restrict to checkin ids whose `contributesTo` matches a precomputed task id list. */
   taskIdIn?: string[];
+  /** Restrict to specific check-in IDs (e.g. filtered by unlocked badge). */
+  checkinIdIn?: string[];
   /** When `true` keep only checkins with images, `false` only those without. */
   hasPhotos?: boolean;
   /** When `true` keep only checkins that solved a task, `false` the rest. */
@@ -124,6 +126,9 @@ export class CheckInDao {
     }
     if (filter.userId) {
       mongoFilter.userId = filter.userId;
+    }
+    if (filter.checkinIdIn && filter.checkinIdIn.length > 0) {
+      mongoFilter._id = { $in: filter.checkinIdIn };
     }
     // taskIdIn ⇒ implies contributed=true. We let it win over the
     // `contributed` flag to avoid producing contradictory queries.

--- a/src/module/checkin/persistence/move.dao.ts
+++ b/src/module/checkin/persistence/move.dao.ts
@@ -50,6 +50,14 @@ export class MoveDao {
     }
   }
 
+  async findMovesByBadge(badgeName: string): Promise<MoveDocument[]> {
+    return this.moveModel.find({ newBadges: badgeName }).exec();
+  }
+
+  async findMovesByCheckinIds(checkinIds: string[]): Promise<MoveDocument[]> {
+    return this.moveModel.find({ checkinId: { $in: checkinIds } }).exec();
+  }
+
   /**
    * Mapea la entidad `Move` al formato del esquema de base de datos `MoveTemplate`.
    */

--- a/src/module/storage/storage.controller.spec.ts
+++ b/src/module/storage/storage.controller.spec.ts
@@ -7,7 +7,6 @@ import { Stream } from 'stream';
 
 describe('StorageController', () => {
   let controller: StorageController;
-  let service: StorageService;
 
   const mockStorageService = {
     getFile: jest.fn(),
@@ -25,7 +24,6 @@ describe('StorageController', () => {
     }).compile();
 
     controller = module.get<StorageController>(StorageController);
-    service = module.get<StorageService>(StorageService);
   });
 
   it('should be defined', () => {

--- a/src/module/storage/storage.service.spec.ts
+++ b/src/module/storage/storage.service.spec.ts
@@ -7,7 +7,6 @@ jest.mock('@aws-sdk/client-s3');
 
 describe('StorageService', () => {
   let service: StorageService;
-  let configService: ConfigService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -26,7 +25,6 @@ describe('StorageService', () => {
     }).compile();
 
     service = module.get<StorageService>(StorageService);
-    configService = module.get<ConfigService>(ConfigService);
   });
 
   it('should be defined', () => {


### PR DESCRIPTION
## What

Adds query filters and badge-based filtering to the `GET /analytics/project/:projectId/community-stats` endpoint, and enriches the admin check-in listing response with gamification data (`newPoints`, `newBadges`).

## Changes

### New endpoint: community stats with filters
`GET /analytics/project/:projectId/community-stats` now accepts the same `AdminCheckinQueryDto` query parameters as the admin check-in listing endpoint:

| Filter | Behaviour |
|---|---|
| `taskType` | Exact match on task type |
| `userId` | Exact match on user |
| `badgeName` | Keeps only check-ins that unlocked the given badge |
| `taskName` | Case-insensitive partial match on task name or description (pushed down to Mongo) |
| `contributed` | `true`/`false` — whether the check-in solved a task |
| `hasPhotos` | `true`/`false` — whether the check-in has images |
| `dateFrom` / `dateTo` | Inclusive date range on `datetime` |
| `latitude` + `longitude` + `radiusKm` | In-memory geo radius filter |

The response shape is unchanged: `{ byArea, byTaskType, byInterval }`.

### Admin check-in listing enrichment
The paginated admin listing (`CheckinService.findForAdmin`) now includes `newPoints` and `newBadges` on each item, sourced from the related `Move`.

### `MoveDao` helpers
Added `findMovesByBadge(badgeName)` and `findMovesByCheckinIds(ids[])` to avoid ad-hoc queries scattered across services.

### Types and code quality
- `CommunityStats`, `AreaStat`, `TaskTypeStat`, `IntervalStat` added to `analytics.types.ts` — `Promise<any>` eliminated from `AnalyticsDao.communityStats`.
- `AdminCheckinPage.items` corrected to `CheckInDocument[]`; `any` casts in the enrichment path of `CheckinService` removed.
- `AnalyticsDao.communityStats` split into `buildCommunityStatsFilter` / `applyGeoRadiusFilter` / `buildCommunityStatsResult` helpers with a JSDoc block.

## Testing

- All existing 52 suites / 384 tests pass.
- `npm run build` and `npm run lint` pass.

Closes #12.