### PR TITLE
feat: add task type description support with external link

### DIFF
--- a/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
+++ b/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
@@ -7,6 +7,7 @@ import { BadRequestException } from '@nestjs/common';
 import { TimeInterval } from '../../../../task/entities/time-restriction.entity';
 import { GeoUtils } from '../../../../task/utils/geoUtils';
 import { GamificationStrategy } from '../../../../project/dto/create-project.dto';
+import { getTaskTypeName } from '../../../../project/entities/task-type';
 
 export class BasicBadgeEngine implements BadgeEngine {
   assignableTo(project: Project): boolean {
@@ -34,13 +35,10 @@ export class BasicBadgeEngine implements BadgeEngine {
   }
 
   private matchTaskType(r: BadgeRule, checkin: Checkin, project: Project) {
-    const taskTypeNames = (project.taskTypes || []).map((t) =>
-      typeof t === 'string' ? t : t?.name,
-    );
+    const taskTypeNames = (project.taskTypes || []).map(getTaskTypeName);
     return (
       r.taskType === 'Cualquiera' ||
-      (checkin.taskType === r.taskType &&
-        taskTypeNames.includes(r.taskType))
+      (checkin.taskType === r.taskType && taskTypeNames.includes(r.taskType))
     );
   }
 

--- a/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
+++ b/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
@@ -34,10 +34,13 @@ export class BasicBadgeEngine implements BadgeEngine {
   }
 
   private matchTaskType(r: BadgeRule, checkin: Checkin, project: Project) {
+    const taskTypeNames = (project.taskTypes || []).map((t) =>
+      typeof t === 'string' ? t : t?.name,
+    );
     return (
       r.taskType === 'Cualquiera' ||
       (checkin.taskType === r.taskType &&
-        project.taskTypes.includes(r.taskType))
+        taskTypeNames.includes(r.taskType))
     );
   }
 

--- a/src/module/project/dto/create-project.dto.ts
+++ b/src/module/project/dto/create-project.dto.ts
@@ -1,4 +1,5 @@
 import { TimeInterval } from '../../task/entities/time-restriction.entity';
+import { TaskTypeValue } from '../entities/task-type';
 
 export enum GamificationStrategy {
   BASIC = 'SIN ADAPTACION',
@@ -23,7 +24,7 @@ export class CreateProjectDto {
   available: boolean;
   manualLocation: boolean;
   areas: FeatureCollection;
-  taskTypes: string[];
+  taskTypes: TaskTypeValue[];
   timeIntervals: TimeInterval[];
   ownerId: string;
   gamificationStrategy?: GamificationStrategy;

--- a/src/module/project/entities/project.ts
+++ b/src/module/project/entities/project.ts
@@ -16,7 +16,7 @@ export class Project {
     web: string,
     available: boolean,
     areas: FeatureCollection,
-    taskTypes: string[],
+    taskTypes: any[],
     timeIntervals: TimeInterval[],
     ownerId: string,
     gamification: Gamification,
@@ -49,7 +49,7 @@ export class Project {
   web: string;
   available: boolean;
   areas: FeatureCollection;
-  taskTypes: string[];
+  taskTypes: any[];
   timeIntervals: TimeInterval[];
   ownerId: string;
   gamification: Gamification;

--- a/src/module/project/entities/project.ts
+++ b/src/module/project/entities/project.ts
@@ -6,6 +6,7 @@ import {
   LeaderboardStrategy,
   RecommendationStrategy,
 } from '../dto/create-project.dto';
+import { TaskTypeValue } from './task-type';
 
 export class Project {
   constructor(
@@ -16,7 +17,7 @@ export class Project {
     web: string,
     available: boolean,
     areas: FeatureCollection,
-    taskTypes: any[],
+    taskTypes: TaskTypeValue[],
     timeIntervals: TimeInterval[],
     ownerId: string,
     gamification: Gamification,
@@ -49,7 +50,7 @@ export class Project {
   web: string;
   available: boolean;
   areas: FeatureCollection;
-  taskTypes: any[];
+  taskTypes: TaskTypeValue[];
   timeIntervals: TimeInterval[];
   ownerId: string;
   gamification: Gamification;

--- a/src/module/project/entities/task-type.spec.ts
+++ b/src/module/project/entities/task-type.spec.ts
@@ -1,0 +1,19 @@
+import { getTaskTypeName } from './task-type';
+
+describe('getTaskTypeName', () => {
+  it('returns the value itself for the legacy string form', () => {
+    expect(getTaskTypeName('Recoger residuos')).toBe('Recoger residuos');
+  });
+
+  it('returns the name for the object form', () => {
+    expect(
+      getTaskTypeName({ name: 'Recoger residuos', description: 'Ver guía' }),
+    ).toBe('Recoger residuos');
+  });
+
+  it('returns the name when the object has no description', () => {
+    expect(getTaskTypeName({ name: 'Recoger residuos' })).toBe(
+      'Recoger residuos',
+    );
+  });
+});

--- a/src/module/project/entities/task-type.ts
+++ b/src/module/project/entities/task-type.ts
@@ -1,0 +1,28 @@
+/**
+ * Task type stored on a project.
+ *
+ * Historically a task type was just its name (`string`). It is being migrated
+ * to a richer object carrying a description (which may embed an external link).
+ * Existing projects still persist the legacy `string` form, so the value is a
+ * union and every consumer must accept both shapes.
+ */
+export interface TaskType {
+  name: string;
+  description?: string;
+}
+
+// Retrocompatibility: the `string` arm must stay until every existing project
+// in the database is migrated from the legacy plain-name form to the object
+// form. Removing it would break reads of old documents (and their gamification
+// rules), which still store task types as bare strings. Drop `string` only once
+// a data migration has backfilled all projects to the object form.
+export type TaskTypeValue = string | TaskType;
+
+/**
+ * Resolve the display name of a task type regardless of which form it takes.
+ * Use this instead of inlining `typeof t === 'string' ? t : t.name` so the
+ * legacy/object handling lives in one place during the migration.
+ */
+export function getTaskTypeName(value: TaskTypeValue): string {
+  return typeof value === 'string' ? value : value?.name;
+}

--- a/src/module/project/persistence/project.schema.ts
+++ b/src/module/project/persistence/project.schema.ts
@@ -6,6 +6,7 @@ import {
   LeaderboardStrategy,
   RecommendationStrategy,
 } from '../dto/create-project.dto';
+import { TaskTypeValue } from '../entities/task-type';
 
 export type ProjectDocument = ProjectTemplate & Document;
 
@@ -32,8 +33,10 @@ export class ProjectTemplate {
   @Prop({ type: MongooseSchema.Types.Mixed, default: {} }) // Permite cualquier tipo
   areas: any;
 
+  // Mixed: persists both the legacy `string` form and the `{ name, description }`
+  // object form. See TaskTypeValue.
   @Prop({ type: [MongooseSchema.Types.Mixed], default: [] })
-  taskTypes: any[];
+  taskTypes: TaskTypeValue[];
 
   @Prop({ default: GamificationStrategy.BASIC })
   gamificationStrategy: string;

--- a/src/module/project/persistence/project.schema.ts
+++ b/src/module/project/persistence/project.schema.ts
@@ -32,8 +32,8 @@ export class ProjectTemplate {
   @Prop({ type: MongooseSchema.Types.Mixed, default: {} }) // Permite cualquier tipo
   areas: any;
 
-  @Prop({ type: [String], default: [] })
-  taskTypes: string[];
+  @Prop({ type: [MongooseSchema.Types.Mixed], default: [] })
+  taskTypes: any[];
 
   @Prop({ default: GamificationStrategy.BASIC })
   gamificationStrategy: string;

--- a/src/module/project/project.builder.ts
+++ b/src/module/project/project.builder.ts
@@ -7,6 +7,7 @@ import {
   LeaderboardStrategy,
   RecommendationStrategy,
 } from './dto/create-project.dto';
+import { TaskTypeValue } from './entities/task-type';
 
 class ProjectBuilder {
   private id: string;
@@ -16,7 +17,7 @@ class ProjectBuilder {
   private web: string;
   private available: boolean;
   private areas: FeatureCollection;
-  private taskTypes: string[];
+  private taskTypes: TaskTypeValue[];
   private timeIntervals: TimeInterval[];
   private ownerId: string;
   private gamification: Gamification;
@@ -78,7 +79,7 @@ class ProjectBuilder {
     return this;
   }
 
-  withTaskTypes(taskTypes: string[]): this {
+  withTaskTypes(taskTypes: TaskTypeValue[]): this {
     this.taskTypes = taskTypes;
     return this;
   }

--- a/src/module/project/project.service.ts
+++ b/src/module/project/project.service.ts
@@ -5,6 +5,7 @@ import { ProjectTemplate } from './persistence/project.schema';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { UserService } from '../auth/users/user.service';
 import { Project } from './entities/project';
+import { getTaskTypeName } from './entities/task-type';
 import { BadgeRule } from '../gamification/entities/gamification.entity';
 import { LeaderboardService } from '../leaderboard/leaderboard.service';
 import { Leaderboard } from '../leaderboard/persistence/leaderboard-user-schema';
@@ -78,7 +79,7 @@ export class ProjectService {
     const combinations = [];
     project.areas.features.map((area) => {
       project.taskTypes.forEach((typeObj) => {
-        const typeName = typeof typeObj === 'string' ? typeObj : typeObj.name;
+        const typeName = getTaskTypeName(typeObj);
         project.timeIntervals.forEach((timeInterval) => {
           combinations.push([
             {

--- a/src/module/project/project.service.ts
+++ b/src/module/project/project.service.ts
@@ -77,7 +77,8 @@ export class ProjectService {
     }
     const combinations = [];
     project.areas.features.map((area) => {
-      project.taskTypes.forEach((type) => {
+      project.taskTypes.forEach((typeObj) => {
+        const typeName = typeof typeObj === 'string' ? typeObj : typeObj.name;
         project.timeIntervals.forEach((timeInterval) => {
           combinations.push([
             {
@@ -87,7 +88,7 @@ export class ProjectService {
               projectId: id,
               timeInterval,
               area,
-              type,
+              type: typeName,
             },
           ]);
         });


### PR DESCRIPTION
Closes https://github.com/Rayuela-v2/rayuela-NodeBackend/issues/13

This PR implements task type description support with external links on the backend, allowing administrators to attach descriptions and clickable links to task types.