### PR TITLE
feat: replace bipartite matching with recursive DAG evaluation in gamification engine

### DIFF
--- a/src/module/checkin/checkin.service.spec.ts
+++ b/src/module/checkin/checkin.service.spec.ts
@@ -25,6 +25,7 @@ const mockCheckInDao = {
   remove: jest.fn(),
   findByProjectId: jest.fn(),
   findForAdmin: jest.fn(),
+  findAllByProjectIdAndUser: jest.fn().mockResolvedValue([]),
 };
 
 const mockIdempotencyDao = {

--- a/src/module/checkin/checkin.service.ts
+++ b/src/module/checkin/checkin.service.ts
@@ -333,6 +333,12 @@ export class CheckinService {
       createCheckinDto.projectId,
     );
     const user = await this.userService.getByUserId(createCheckinDto.userId);
+
+    user.checkins = await this.checkInDao.findAllByProjectIdAndUser(
+      createCheckinDto.userId,
+      createCheckinDto.projectId,
+    );
+
     const users = await this.userService.findAllByProjectId(
       createCheckinDto.projectId,
     );

--- a/src/module/checkin/persistence/checkin.dao.ts
+++ b/src/module/checkin/persistence/checkin.dao.ts
@@ -107,6 +107,17 @@ export class CheckInDao {
       .exec();
   }
 
+  async findAllByProjectIdAndUser(
+    userId: string,
+    projectId: string,
+  ): Promise<Checkin[]> {
+    const list = await this.checkInModel
+      .find({ projectId, userId })
+      .sort({ datetime: 1 })
+      .exec();
+    return list.map((c) => CheckinMapper.toEntity(c, null));
+  }
+
   /**
    * Admin endpoint backbone: builds a Mongo filter from `AdminCheckinFilter`,
    * paginates, and returns total count for the UI to render page controls.

--- a/src/module/gamification/entities/engine/gamification/basic-badge-engine.spec.ts
+++ b/src/module/gamification/entities/engine/gamification/basic-badge-engine.spec.ts
@@ -55,6 +55,102 @@ describe('BasicBadgeEngine', () => {
       const result = engine.newBadgesFor(user, checkin, project);
       expect(result).toContain(rule);
     });
+
+    it('should bypass faded prerequisite badges and award active child badge', () => {
+      const ruleA = new BadgeRule(
+        'rA',
+        'p1',
+        'BadgeA',
+        'desc',
+        'img',
+        1,
+        false,
+        [],
+        'Cualquiera',
+        'A1',
+        'Cualquiera',
+        'faded',
+      );
+      const ruleB = new BadgeRule(
+        'rB',
+        'p1',
+        'BadgeB',
+        'desc',
+        'img',
+        1,
+        false,
+        ['BadgeA'],
+        'Cualquiera',
+        'A2',
+        'Cualquiera',
+        'active',
+      );
+
+      const featureA1 = {
+        properties: { id: 'A1' },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      };
+      const featureA2 = {
+        properties: { id: 'A2' },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [2, 2],
+              [3, 2],
+              [3, 3],
+              [2, 3],
+              [2, 2],
+            ],
+          ],
+        },
+      };
+
+      const project = {
+        id: 'p1',
+        gamification: { badgesRules: [ruleA, ruleB] },
+        taskTypes: ['type1'],
+        timeIntervals: [],
+        areas: { features: [featureA1, featureA2] },
+      } as any;
+
+      const user = new User('t@t.com', 'u', 'p', 'T');
+      user.id = 'u1';
+      user.addProject('p1');
+      const checkin1 = {
+        date: new Date(),
+        taskType: 'type1',
+        longitude: '0.5',
+        latitude: '0.5',
+        contributesTo: '',
+        projectId: 'p1',
+      } as any;
+      user.checkins = [checkin1];
+
+      const checkin2 = {
+        date: new Date(),
+        taskType: 'type1',
+        longitude: '2.5',
+        latitude: '2.5',
+        contributesTo: '',
+        projectId: 'p1',
+      } as any;
+
+      const result = engine.newBadgesFor(user, checkin2, project);
+      expect(result).toContain(ruleB);
+      expect(result).not.toContain(ruleA);
+    });
   });
 
   describe('internal matches', () => {
@@ -176,15 +272,180 @@ describe('BasicBadgeEngine', () => {
       const checkin = { longitude: '0.5', latitude: '0.5' } as any;
       expect((engine as any).matchArea(rule2, checkin, project)).toBe(true);
     });
-    it('should check if user has previous badges', () => {
-      const rule = { previousBadges: ['B1'] } as any;
-      const user = { hasBadgeWithName: jest.fn() } as any;
+    it('should check if user has previous badges satisfied recursively', () => {
+      const b1 = new BadgeRule(
+        'r1',
+        'p1',
+        'B1',
+        'd',
+        'i',
+        1,
+        false,
+        [],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'faded',
+      );
+      const b2 = new BadgeRule(
+        'r2',
+        'p1',
+        'B2',
+        'd',
+        'i',
+        1,
+        false,
+        ['B1'],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+      );
+      const proj = {
+        gamification: { badgesRules: [b1, b2] },
+      } as any;
 
-      user.hasBadgeWithName.mockReturnValue(true);
-      expect((engine as any).userHasPreviousBadges(rule, user)).toBe(true);
+      const checkinsEmpty: any[] = [];
+      const checkinOk = {
+        date: new Date(),
+        taskType: 'type1',
+        longitude: '0',
+        latitude: '0',
+      } as any;
 
-      user.hasBadgeWithName.mockReturnValue(false);
-      expect((engine as any).userHasPreviousBadges(rule, user)).toBe(false);
+      expect(
+        engine.isBadgeSatisfied(b2, checkinsEmpty, proj, [], new Map()),
+      ).toBe(false);
+      expect(
+        engine.isBadgeSatisfied(
+          b2,
+          [checkinOk, checkinOk],
+          proj,
+          [],
+          new Map(),
+        ),
+      ).toBe(true);
+    });
+
+    it('should evaluate 3-layer faded badge chain (A -> B -> C) as satisfied recursively with check-ins', () => {
+      const a = new BadgeRule(
+        'rA',
+        'p1',
+        'A',
+        'd',
+        'i',
+        1,
+        false,
+        [],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'faded',
+      );
+      const b = new BadgeRule(
+        'rB',
+        'p1',
+        'B',
+        'd',
+        'i',
+        1,
+        false,
+        ['A'],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'faded',
+      );
+      const c = new BadgeRule(
+        'rC',
+        'p1',
+        'C',
+        'd',
+        'i',
+        1,
+        false,
+        ['B'],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'active',
+      );
+      const proj = {
+        gamification: { badgesRules: [a, b, c] },
+      } as any;
+
+      const ch = {
+        date: new Date(),
+        taskType: 'type1',
+        longitude: '0',
+        latitude: '0',
+      } as any;
+
+      // 0 check-ins should NOT satisfy C
+      expect(engine.isBadgeSatisfied(c, [], proj, [], new Map())).toBe(false);
+
+      // 1 check-in should satisfy C recursively
+      expect(engine.isBadgeSatisfied(c, [ch], proj, [], new Map())).toBe(true);
+    });
+
+    it('should evaluate branching faded prerequisites correctly (B, C -> A) recursively', () => {
+      const b = new BadgeRule(
+        'rB',
+        'p1',
+        'B',
+        'd',
+        'i',
+        1,
+        false,
+        [],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'faded',
+      );
+      const c = new BadgeRule(
+        'rC',
+        'p1',
+        'C',
+        'd',
+        'i',
+        1,
+        false,
+        [],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'faded',
+      );
+      const a = new BadgeRule(
+        'rA',
+        'p1',
+        'A',
+        'd',
+        'i',
+        1,
+        false,
+        ['B', 'C'],
+        'Cualquiera',
+        'Cualquiera',
+        'Cualquiera',
+        'active',
+      );
+      const proj = {
+        gamification: { badgesRules: [b, c, a] },
+      } as any;
+
+      const ch = {
+        date: new Date(),
+        taskType: 'type1',
+        longitude: '0',
+        latitude: '0',
+      } as any;
+
+      // 0 check-ins should NOT satisfy A
+      expect(engine.isBadgeSatisfied(a, [], proj, [], new Map())).toBe(false);
+
+      // 1 check-in should satisfy A recursively
+      expect(engine.isBadgeSatisfied(a, [ch], proj, [], new Map())).toBe(true);
     });
   });
 });

--- a/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
+++ b/src/module/gamification/entities/engine/gamification/basic-badge-engine.ts
@@ -8,29 +8,98 @@ import { TimeInterval } from '../../../../task/entities/time-restriction.entity'
 import { GeoUtils } from '../../../../task/utils/geoUtils';
 import { GamificationStrategy } from '../../../../project/dto/create-project.dto';
 import { getTaskTypeName } from '../../../../project/entities/task-type';
-
 export class BasicBadgeEngine implements BadgeEngine {
   assignableTo(project: Project): boolean {
     return project.gamificationStrategy === GamificationStrategy.BASIC;
   }
 
   newBadgesFor(u: User, ch: Checkin, project: Project): BadgeRule[] {
-    return project.gamification.badgesRules.filter(
-      (r) =>
-        this.ruleMatch(r, ch, project, u) &&
-        !u
-          .getGameProfileFromProject(project.id)
-          .badges.find((b) => b === r.name),
+    const memo = new Map<string, boolean>();
+    const allCheckins = [...(u.checkins || []), ch];
+    const currentBadges = u.getGameProfileFromProject(project.id)?.badges || [];
+
+    const satisfiedBadges = project.gamification.badgesRules.filter((badge) =>
+      this.isBadgeSatisfied(badge, allCheckins, project, currentBadges, memo),
+    );
+
+    const earnableBadges = satisfiedBadges.filter(
+      (badge) => badge.status === 'active',
+    );
+
+    return earnableBadges.filter(
+      (badge) => !currentBadges.includes(badge.name),
     );
   }
 
-  private ruleMatch(r: BadgeRule, checkin: Checkin, project: Project, u: User) {
+  /**
+   * Recursively evaluates if a badge is satisfied based on check-in history.
+   * A badge is satisfied if:
+   * 1. All previous prerequisite badges are recursively satisfied.
+   * 2. The user has enough check-ins satisfying the criteria for this badge specifically.
+   */
+  isBadgeSatisfied(
+    badge: BadgeRule,
+    checkins: Checkin[],
+    project: Project,
+    currentBadges: string[],
+    memo: Map<string, boolean>,
+  ): boolean {
+    if (memo.has(badge.name)) {
+      return memo.get(badge.name)!;
+    }
+
+    // 1. Evaluate prerequisite badges recursively (DAG evaluation)
+    let prereqsSatisfied = true;
+    for (const prereqName of badge.previousBadges || []) {
+      const prereqRule = project.gamification.badgesRules.find(
+        (rule) => rule.name === prereqName,
+      );
+      if (!prereqRule) {
+        prereqsSatisfied = false;
+        break;
+      }
+
+      const isPrereqSatisfied = this.isBadgeSatisfied(
+        prereqRule,
+        checkins,
+        project,
+        currentBadges,
+        memo,
+      );
+
+      if (!isPrereqSatisfied) {
+        prereqsSatisfied = false;
+        break;
+      }
+    }
+
+    if (!prereqsSatisfied) {
+      memo.set(badge.name, false);
+      return false;
+    }
+
+    // 2. Validate current badge's own check-in requirements
+    const matchingCheckins = checkins.filter((ch) =>
+      this.matchesBadgeCriteria(badge, ch, project),
+    );
+    const selfSatisfied =
+      matchingCheckins.length >= (badge.checkinsAmount || 1);
+
+    const isSatisfied = selfSatisfied;
+    memo.set(badge.name, isSatisfied);
+    return isSatisfied;
+  }
+
+  matchesBadgeCriteria(
+    badge: BadgeRule,
+    ch: Checkin,
+    project: Project,
+  ): boolean {
     return (
-      this.userHasPreviousBadges(r, u) &&
-      this.matchTaskType(r, checkin, project) &&
-      this.matchTimeInterval(r, checkin, project) &&
-      this.matchArea(r, checkin, project) &&
-      this.verifyContributes(r, checkin)
+      this.matchTaskType(badge, ch, project) &&
+      this.matchTimeInterval(badge, ch, project) &&
+      this.matchArea(badge, ch, project) &&
+      this.verifyContributes(badge, ch)
     );
   }
 
@@ -83,10 +152,6 @@ export class BasicBadgeEngine implements BadgeEngine {
         polygon.geometry,
       )
     );
-  }
-
-  private userHasPreviousBadges(r: BadgeRule, u: User) {
-    return r.previousBadges.every((b) => u.hasBadgeWithName(b));
   }
 
   private verifyContributes(r: BadgeRule, checkin: Checkin) {

--- a/src/module/gamification/entities/gamification.entity.ts
+++ b/src/module/gamification/entities/gamification.entity.ts
@@ -29,6 +29,7 @@ export class BadgeRule {
     taskType: string,
     areaId: string,
     timeIntervalId: string,
+    status = 'active',
   ) {
     this._id = id;
     this.projectId = projectId;
@@ -41,6 +42,7 @@ export class BadgeRule {
     this.taskType = taskType;
     this.areaId = areaId;
     this.timeIntervalId = timeIntervalId;
+    this.status = status;
   }
 
   _id: string;
@@ -54,6 +56,7 @@ export class BadgeRule {
   taskType: string;
   areaId: string;
   timeIntervalId: string;
+  status: string;
 }
 
 export class PointRule {

--- a/src/module/gamification/gamification.service.ts
+++ b/src/module/gamification/gamification.service.ts
@@ -30,6 +30,10 @@ export class GamificationService {
     return this.gamificationDao.deleteBadge(projectId, id);
   }
 
+  updateBadgeStatus(projectId: string, id: string, status: string) {
+    return this.gamificationDao.updateBadgeStatus(projectId, id, status);
+  }
+
   updateBadge(id: string, updateBadgeDTO: UpdateBadgeRuleDTO) {
     return this.gamificationDao.updateBadge(id, updateBadgeDTO);
   }

--- a/src/module/gamification/gamificationController.spec.ts
+++ b/src/module/gamification/gamificationController.spec.ts
@@ -10,6 +10,7 @@ describe('GamificationController', () => {
     createBadge: jest.fn(),
     updateBadge: jest.fn(),
     removeBadge: jest.fn(),
+    updateBadgeStatus: jest.fn(),
     createScoreRule: jest.fn(),
     updateScoreRule: jest.fn(),
     removeScoreRule: jest.fn(),
@@ -49,6 +50,15 @@ describe('GamificationController', () => {
     it('should remove badge', async () => {
       await controller.remove('p1', 'b1');
       expect(service.removeBadge).toHaveBeenCalledWith('p1', 'b1');
+    });
+
+    it('should update badge status', async () => {
+      await controller.updateBadgeStatus('p1', 'b1', 'active');
+      expect(service.updateBadgeStatus).toHaveBeenCalledWith(
+        'p1',
+        'b1',
+        'active',
+      );
     });
   });
 

--- a/src/module/gamification/gamificationController.ts
+++ b/src/module/gamification/gamificationController.ts
@@ -6,7 +6,9 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { GamificationService } from './gamification.service';
 import { CreateBadgeRuleDTO } from './dto/create-badge-rule-d-t.o';
 import { UpdateGamificationDto } from './dto/update-gamification.dto';
@@ -34,6 +36,16 @@ export class GamificationController {
   @Delete('/:projectId/badge/:id')
   remove(@Param('projectId') projectId: string, @Param('id') id: string) {
     return this.gamificationService.removeBadge(projectId, id);
+  }
+
+  @Patch('/:projectId/badge/:id/status/:status')
+  @UseGuards(AuthGuard('jwt'))
+  updateBadgeStatus(
+    @Param('projectId') projectId: string,
+    @Param('id') id: string,
+    @Param('status') status: string,
+  ) {
+    return this.gamificationService.updateBadgeStatus(projectId, id, status);
   }
 
   @Post('score-rule')

--- a/src/module/gamification/persistence/gamification-dao.service.ts
+++ b/src/module/gamification/persistence/gamification-dao.service.ts
@@ -94,6 +94,20 @@ export class GamificationDao {
       .exec();
   }
 
+  async updateBadgeStatus(
+    projectId: string,
+    badgeId: string,
+    status: string,
+  ): Promise<GamificationTemplate | null> {
+    return this.gamificationModel
+      .findOneAndUpdate(
+        { projectId, 'badges._id': badgeId },
+        { $set: { 'badges.$.status': status } },
+        { new: true },
+      )
+      .exec();
+  }
+
   async addScoreRule(
     projectId: string,
     pointRule: CreateScoreRuleDto,
@@ -154,6 +168,7 @@ export class GamificationDao {
             b.taskType,
             b.areaId,
             b.timeIntervalId,
+            b.status || 'active',
           ),
       ),
       saved.pointRules.map(

--- a/src/module/gamification/persistence/gamification.schema.ts
+++ b/src/module/gamification/persistence/gamification.schema.ts
@@ -35,6 +35,13 @@ export class BadgeTemplate {
 
   @Prop({ required: true })
   timeIntervalId: string;
+
+  @Prop({
+    required: true,
+    default: 'active',
+    enum: ['active', 'faded', 'expired'],
+  })
+  status?: string;
 }
 
 const BadgeTemplateSchema = SchemaFactory.createForClass(BadgeTemplate);

--- a/src/module/project/project-service.spec.ts
+++ b/src/module/project/project-service.spec.ts
@@ -9,6 +9,14 @@ import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { LeaderboardService } from '../leaderboard/leaderboard.service';
 import { BadgeRule } from '../gamification/entities/gamification.entity';
+import { getModelToken } from '@nestjs/mongoose';
+import { CheckInTemplate } from '../checkin/persistence/checkin.schema';
+
+const mockCheckInModel = {
+  find: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  exec: jest.fn().mockResolvedValue([]),
+};
 
 const mockProjectDao = {
   create: jest.fn(),
@@ -36,6 +44,10 @@ describe('ProjectService', () => {
         { provide: ProjectDao, useValue: mockProjectDao },
         { provide: UserService, useValue: mockUserService },
         { provide: LeaderboardService, useValue: mockLeaderboardService },
+        {
+          provide: getModelToken(CheckInTemplate.collectionName()),
+          useValue: mockCheckInModel,
+        },
       ],
     }).compile();
 

--- a/src/module/project/project.module.ts
+++ b/src/module/project/project.module.ts
@@ -8,11 +8,17 @@ import { AuthModule } from '../auth/auth.module';
 import { GamificationModule } from '../gamification/gamification.module';
 import { LeaderboardModule } from '../leaderboard/leaderboard.module';
 
+import {
+  CheckInSchema,
+  CheckInTemplate,
+} from '../checkin/persistence/checkin.schema';
+
 @Module({
   imports: [
     LeaderboardModule,
     MongooseModule.forFeature([
       { name: ProjectTemplate.collectionName(), schema: ProjectSchema },
+      { name: CheckInTemplate.collectionName(), schema: CheckInSchema },
     ]),
     AuthModule,
     GamificationModule,

--- a/src/module/project/project.service.ts
+++ b/src/module/project/project.service.ts
@@ -9,6 +9,14 @@ import { getTaskTypeName } from './entities/task-type';
 import { BadgeRule } from '../gamification/entities/gamification.entity';
 import { LeaderboardService } from '../leaderboard/leaderboard.service';
 import { Leaderboard } from '../leaderboard/persistence/leaderboard-user-schema';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  CheckInTemplate,
+  CheckInDocument,
+} from '../checkin/persistence/checkin.schema';
+import { CheckinMapper } from '../checkin/persistence/CheckinMapper';
+import { BasicBadgeEngine } from '../gamification/entities/engine/gamification/basic-badge-engine';
 
 export interface UserStatus {
   isSubscribed: boolean;
@@ -23,6 +31,8 @@ export class ProjectService {
     private readonly projectDao: ProjectDao,
     private readonly userService: UserService,
     private readonly leaderboardService: LeaderboardService,
+    @InjectModel(CheckInTemplate.collectionName())
+    private readonly checkInModel: Model<CheckInDocument>,
   ) {}
 
   async findAll(): Promise<(ProjectTemplate & { _id: string })[]> {
@@ -37,6 +47,15 @@ export class ProjectService {
     if (userId) {
       const user = await this.userService.getByUserId(userId);
       const gp = user.getGameProfileFromProject(project.id);
+
+      const checkinDocs = await this.checkInModel
+        .find({ projectId: project.id, userId })
+        .sort({ datetime: 1 })
+        .exec();
+      const checkins = checkinDocs.map((c) => CheckinMapper.toEntity(c, null));
+      const badgeEngine = new BasicBadgeEngine();
+      const memo = new Map<string, boolean>();
+
       return {
         ...project,
         user: gp && {
@@ -44,6 +63,13 @@ export class ProjectService {
           badges: project.gamification.badgesRules.map((b) => ({
             ...b,
             active: gp.badges.includes(b.name),
+            satisfied: badgeEngine.isBadgeSatisfied(
+              b,
+              checkins,
+              project,
+              gp.badges || [],
+              memo,
+            ),
           })),
           points: gp?.points,
           leaderboard: await this.leaderboardService.getLeaderboardFor(


### PR DESCRIPTION
## Overview
This PR refactors the gamification engine's badge satisfaction checks to transition from a maximum bipartite matching model to a recursive Directed Acyclic Graph (DAG) evaluation algorithm.

### What is Changing and Why?
- **Old Approach**: The previous engine computed a global closure of faded intermediate badges and used maximum bipartite matching (`BipartiteMatcher`) to uniquely allocate check-in slots across the entire closure. This was mathematically complex, resource-heavy, and imposed strict unique-slot consumption rules across all badges.
- **New Approach**: Evaluates badge satisfaction recursively. A badge is satisfied if:
  1. All of its prerequisite parent badges are recursively satisfied (transitive historical satisfaction).
  2. Its own criteria (area, time interval, task type) and `checkinsAmount` are met by the check-in history.
- **Code Cleanup**: Removed the deprecated `BipartiteMatcher` class, its tests, and simplified NestJS endpoints to use a protected `/status/:status` PATCH route.

### Key Capabilities Enabled
- **Decoupled Badge Satisfaction**: Allows granting badges that are not directly tied to the target criteria of the current check-in. The DAG recursion handles traversing historical check-ins per node instead of enforcing a strict matching constraint.
- **Badge Fading Strategy**: Empowers "Badge Fading" as an adaptive gamification mechanism. Faded prerequisite badges are bypassed historically to unlock downstream active badges.
- **Testing & Administration**: Exposes an authenticated route to dynamically change badge status (`active` vs `faded`) for testing gamification rules.

### How Collaborators Perceive Faded Badges (Mobile/UI)
Faded status changes how badges are visually represented to the volunteer:
- **Red Border & Desaturation**: Unsatisfied faded badges show with a red border and a desaturated icon overlay.
- **Orange Border & Glow**: Historically satisfied (but faded) badges glow orange to show they are satisfied but cannot be directly earned.
- **Red Dashed Edges**: Paths between faded badges are rendered as red dashed curves on the dependency graph.